### PR TITLE
#153722607 Add initial database seeders

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Auth\Authenticatable;
 use Laravel\Lumen\Auth\Authorizable;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
-use App\Models\LostItem;
 use Illuminate\Auth\Authenticatable;
 use Laravel\Lumen\Auth\Authorizable;
 use Illuminate\Database\Eloquent\Model;

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -11,9 +11,8 @@
 |
 */
 
-$factory->define(App\User::class, function (Faker\Generator $faker) {
+$factory->define(App\Models\Category::class, function (Faker\Generator $faker) {
     return [
-        'name' => $faker->name,
-        'email' => $faker->email,
+        'name' => $faker->unique()->randomElement(["card", "phones", "clothes", "others"]),
     ];
 });

--- a/database/factories/LostItemFactory.php
+++ b/database/factories/LostItemFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| Here you may define all of your model factories. Model factories give
+| you a convenient way to create models for testing and seeding your
+| database. Just tell the factory how a default model should look.
+|
+*/
+
+$factory->define(App\Models\LostItem::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->text(10),
+        'found' => $faker->boolean(20),
+        'category' => $faker->numberBetween(1, 4),
+        'owner' => $faker->numberBetween(1, 10),
+        'finder' => $faker->numberBetween(1, 10),
+    ];
+});

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| Here you may define all of your model factories. Model factories give
+| you a convenient way to create models for testing and seeding your
+| database. Just tell the factory how a default model should look.
+|
+*/
+
+$factory->define(App\Models\User::class, function (Faker\Generator $faker) {
+    return [
+        'user_name' => $faker->userName,
+        'email' => $faker->email,
+        'phone' => $faker->phoneNumber,
+        'first_name' => $faker->firstName,
+        'last_name' => $faker->lastName,
+        'location' => $faker->city,
+    ];
+});

--- a/database/migrations/2017_12_16_132942_create_users_table.php
+++ b/database/migrations/2017_12_16_132942_create_users_table.php
@@ -15,12 +15,12 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
+            $table->string('phone')->unique();
             $table->string('user_name')->nullable();
-            $table->string('email')->unique();
+            $table->string('email')->nullable()->unique();
             $table->string('first_name')->nullable();
             $table->string('last_name')->nullable();
             $table->string('location')->nullable();
-            $table->json('contact_info');
             $table->timestamps();
         });
     }

--- a/database/migrations/2017_12_16_133025_create_categories_table.php
+++ b/database/migrations/2017_12_16_133025_create_categories_table.php
@@ -15,7 +15,7 @@ class CreateCategoriesTable extends Migration
     {
         Schema::create('categories', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
             $table->timestamps();
         });
     }

--- a/database/migrations/2017_12_16_135711_create_lost_items_table.php
+++ b/database/migrations/2017_12_16_135711_create_lost_items_table.php
@@ -16,9 +16,9 @@ class CreateLostItemsTable extends Migration
         Schema::create('lost_items', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
-            $table->integer('category')->unsigned();
-            $table->integer('finder')->unsigned();
-            $table->integer('owner')->unsigned();
+            $table->integer('category')->unsigned()->nullable();
+            $table->integer('finder')->unsigned()->nullable();
+            $table->integer('owner')->unsigned()->nullable();
             $table->boolean('found');
             $table->foreign('category')
                 ->references('id')->on('categories')

--- a/database/seeds/CategoryTableSeeder.php
+++ b/database/seeds/CategoryTableSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class CategoryTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\Models\Category::class, 4)->create();
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call('UsersTableSeeder');
+         $this->call('UserTableSeeder');
+         $this->call('CategoryTableSeeder');
+         $this->call('LostItemTableSeeder');
     }
 }

--- a/database/seeds/LostItemTableSeeder.php
+++ b/database/seeds/LostItemTableSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class LostItemTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\Models\LostItem::class, 40)->create();
+    }
+}

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UserTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        factory(App\Models\User::class, 10)->create();
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Currently, there are no database seeders to seed data to the database.

This PR adds database seeders for testing and development in an attempt to help in getting data fast and easily. 

### Description of task to be completed
There is need for there to be database seeders for users, categories and lost items in order to make development easy.

### How should this be manually tested?
On the terminal, run the command `php artisan db:seed`. You should find data on users, categories and lostitems in the categories.

### What are the relevant PT stories?
[#153722607](https://www.pivotaltracker.com/story/show/153722607)

### Any background context
N/A