### PR TITLE
#153726799 Add endpoint to get filtered lost items

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,16 @@ jobs:
           APP_ENV: testing
           APP_DEBUG: true
           APP_KEY: thisisarandomkey
-          DB_CONNECTION: psql
+          DB_CONNECTION: pgsql
           DB_HOST: 127.0.0.1
           DB_PORT: 5432
           DB_DATABASE: finder_test
-          DB_USERNAME: php
+          DB_USERNAME: ubuntu
           QUEUE_DRIVER: sync
       - image: postgres
         environment:
-          POSTGRES_DATABASE: finder_test
-          POSTGRES_PASSWORD: finder_password
+          POSTGRES_DB: finder_test
+          POSTGRES_USER: ubuntu
     working_directory: ~/lumen
     steps:
       - run:

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Response;
 use Laravel\Lumen\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
-    //
+    protected function respond($response, $httpStatus) {
+        return new Response($response, $httpStatus);
+    }
 }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Models\LostItem;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class ItemController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Gets lost items that match filter parameters
+     *
+     * @param Request $request - Request object
+     *
+     * @return object $response - Response object
+     */
+    public function get(Request $request)
+    {
+        try {
+            $limit = $request->get("limit") ?
+                intval($request->get("limit")) : 20;
+            $params = [];
+
+            if ($query = $request->get("q")) {
+                $params["searchQuery"] = $query;
+            }
+            if ($type = $request->get("reporter")) {
+                $params["reporter"] = $type;
+            }
+            if($categories = $request->get("categories")) {
+                $params["categories"] = explode(",", $categories);
+            }
+
+            $lostItems = LostItem::buildItemsQuery($params)
+                ->orderBy("created_at", "desc")
+                ->paginate($limit);
+
+            $response["items"] = $this->formatItemData($lostItems);
+            $response["pagination"] = [
+                "totalCount" => $lostItems->total(),
+                "pageSize" => $lostItems->perPage(),
+                "lastPage" => $lostItems->lastPage(),
+                "currentPage" => $lostItems->currentPage(),
+            ];
+
+            return $response;
+        } catch(QueryException $exception) {
+            $response = [
+                "message" => "You have entered wrong parameter. Please review and try again"
+            ];
+            return $this->respond($response, 400);
+        }
+    }
+
+    /**
+     * Format request data
+     * extracts returned request queries to match data on client side
+     *
+     * @param Object $items - collection of items
+     *
+     * @return array - array of formatted items
+     */
+    private function formatItemData($items)
+    {
+        $formattedItems = [];
+        foreach ($items as $item) {
+            $formattedItem = (object) [
+                "id" => $item->id,
+                "name" => $item->name,
+                "category" => Category::find($item->category)->name,
+                "finder" => $item->finder,
+                "owner" => $item->owner,
+                "found" => $item->found,
+                "dateCreated" => $this->formatTime($item->created_at),
+                "dateUpdated" => $this->formatTime($item->updated_at)
+            ];
+            $formattedItems[] = $formattedItem;
+        }
+        return $formattedItems;
+    }
+
+    /**
+     * Checks if the given time is null and returns null else it returns
+     * the time in the date format
+     *
+     * @param string $time - the time in the date format
+     *
+     * @return mixed null|string
+     */
+    private function formatTime($time)
+    {
+        return $time === null ? null : date("Y-m-d H:i:s", $time->getTimestamp());
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -23,9 +23,9 @@ $app = new Laravel\Lumen\Application(
     realpath(__DIR__.'/../')
 );
 
-// $app->withFacades();
+ $app->withFacades();
 
-// $app->withEloquent();
+ $app->withEloquent();
 
 /*
 |--------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "scripts": {
         "post-root-package-install": [
             "php -r \"copy('.env.example', '.env');\""
-        ]
+        ],
+        "test": "phpunit --debug --coverage-clover build/logs/clover.xml"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/database/factories/LostItemFactory.php
+++ b/database/factories/LostItemFactory.php
@@ -16,7 +16,11 @@ $factory->define(App\Models\LostItem::class, function (Faker\Generator $faker) {
         'name' => $faker->text(10),
         'found' => $faker->boolean(20),
         'category' => $faker->numberBetween(1, 4),
-        'owner' => $faker->numberBetween(1, 10),
-        'finder' => $faker->numberBetween(1, 10),
+        'finder' => function (array $lostItem) use($faker) {
+            return $lostItem['found'] ? $faker->numberBetween(1, 10) : $faker->randomElement([$faker->numberBetween(1, 10), null]);
+        },
+        'owner' => function (array $lostItem) use ($faker) {
+            return $lostItem['found'] ? $faker->numberBetween(1, 10) : ($lostItem['finder'] ? null : $faker->numberBetween(1, 10));
+        }
     ];
 });

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,5 +23,7 @@
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="DB_DATABASE" value="finder_test"/>
+        <env name="DB_USERNAME" value="php"/>
     </php>
 </phpunit>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,13 @@
 |
 */
 
-$router->get('/', function () use ($router) {
+$router->get("/", function () use ($router) {
     return $router->app->version();
+});
+
+/**
+ * Routes for items
+ */
+$router->group(["prefix" => "api/v1"], function ($router) {
+    $router->get("items", "ItemController@get");
 });

--- a/tests/App/Http/Controllers/ItemControllerTest.php
+++ b/tests/App/Http/Controllers/ItemControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Test\App\Http\Controllers\V2;
+
+use TestCase;
+
+class ItemControllerTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Test that items are gotten succesfully
+     */
+    public function testGetLostItemsSuccess()
+    {
+        $this->get("api/v1/items");
+
+        $response = json_decode($this->response->getContent());
+
+        $this->assertResponseStatus(200);
+        $this->assertEquals(count($response->items), 20);
+
+        $singleItem = $response->items[0];
+
+        $this->assertObjectHasAttribute("id", $singleItem);
+        $this->assertObjectHasAttribute("name", $singleItem);
+        $this->assertObjectHasAttribute("category", $singleItem);
+        $this->assertObjectHasAttribute("finder", $singleItem);
+        $this->assertObjectHasAttribute("owner", $singleItem);
+        $this->assertObjectHasAttribute("found", $singleItem);
+        $this->assertObjectHasAttribute("dateCreated", $singleItem);
+        $this->assertObjectHasAttribute("dateUpdated", $singleItem);
+    }
+
+    /**
+     * Test that wrong params fail test
+     */
+    public function testGetLostItemsFailureInvalidReporter()
+    {
+        $this->get("api/v1/items?reporter=wrongFinder");
+        $this->assertResponseStatus(400);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,4 +11,12 @@ abstract class TestCase extends Laravel\Lumen\Testing\TestCase
     {
         return require __DIR__.'/../bootstrap/app.php';
     }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->artisan("migrate:refresh");
+        $this->artisan("db:seed");
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Currently, there is no functionality for an endpoint to get items.

This PR adds a get function that receives get request and returns lost items. It also accepts url parameters thus can filter the items based on `searchQuery`(q), `categories`, and `reporter`(person who reported item lost or found).

It also adds a function formatItemData which structures the lost items data.

A function formatTime is added to format time in the `DATE TIME` format.

### Description of task to be completed.
There is need for backend functionality to get paginated lost items that can be filtered by search query, category and whether the item was found.

### How can this be manually tested?
On pivotal tracker, query the endpoint:
`api/v1/items` with the following optional parameters `q` for search queries, `category` which is a comma separated string containing various categories, and `reporter` which is whether the individual who reported the item, was the finder or the owner of the item.

### Relevant PT stories.
[#153726799](https://www.pivotaltracker.com/story/show/153726799)

### Any background context
N/A